### PR TITLE
import multiprocessing for line 43

### DIFF
--- a/examples/flowers/trainer/util.py
+++ b/examples/flowers/trainer/util.py
@@ -2,6 +2,7 @@
 import os
 import io
 import logging
+import multiprocessing
 
 import numpy as np
 from PIL import Image


### PR DESCRIPTION
flake8 testing of https://github.com/Fematich/mlengine-boilerplate on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/flowers/preprocess.py:24:19: E999 SyntaxError: invalid syntax
def build_example((key, label, img_bytes)):
                  ^
./examples/flowers/trainer/util.py:42:23: F821 undefined name 'multiprocessing'
        num_threads = multiprocessing.cpu_count() if multi_threading else 1
                      ^
./examples/flowers/trainer/util.py:51:50: F821 undefined name 'printout'
        dataset = dataset.map(lambda tf_example: printout(tf_example))
                                                 ^
./trainer/util.py:44:50: F821 undefined name 'printout'
        dataset = dataset.map(lambda tf_example: printout(tf_example))
                                                 ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'multiprocessing'
4
```

On the first error above, it is a syntax error in Python 3 to have an explicit tuple as a parameter to a function or lambda.